### PR TITLE
Add TravisCI & Coveralls support

### DIFF
--- a/.istanbul.yml
+++ b/.istanbul.yml
@@ -1,2 +1,6 @@
+instrumentation:
+    include-all-sources: true
+    # NOTE : For now ignore the examples & the dynamic generator which is just an experimentation for now
+    excludes :  ['**/examples/**', '**/generators/dynamic-generator.js']
 reporting:
     dir: ./test/coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,4 @@
+language: node_js
+node_js:
+  - 0.12
+script: "npm run coverage"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: node_js
 node_js:
-  - 0.12
+  - 5.12
 script: "npm run coverage"

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,4 @@ language: node_js
 node_js:
   - 5.12
 script: "npm run coverage"
+after_script: "cat ./test/coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js"

--- a/README.md
+++ b/README.md
@@ -1,11 +1,22 @@
-# TestHelper.js
+# TestHelper
 
-This tools help simplify tests.
+[![Build Status](https://travis-ci.org/jpgdev/testhelper.svg?branch=master)](https://travis-ci.org/jpgdev/testhelper)
+[![Coverage Status](https://coveralls.io/repos/github/jpgdev/testhelper/badge.svg?branch=master)](https://coveralls.io/github/jpgdev/testhelper?branch=master)
 
-- Help generating valid models using custom made generators.
-- Help encapsulating server calls
+##### This is a tool to help simplify building integration tests by
+* Generating valid models
+* Simplifying repetitive route calls
 
-_NOTE : This is a temp README file for now._
+## Examples
+
+_TODO : Add examples of usages for the Generator & TestHelper_
+
+## How to use
+
+_TODO : Add documentation on how to use it_
+
+## Features
+- Helps generating valid models using custom made generators.
+- Helps encapsulating server calls
 
 _NOTE : The code is not ready yet, only created this to remove it from the other project I'm using it in._
-

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "test": "./node_modules/.bin/mocha --reporter spec",
     "test-auto": "./node_modules/.bin/mocha --watch --reporter spec",
-    "coverage" : "./node_modules/.bin/istanbul cover node_modules/.bin/_mocha -- -R spec test/**.js"
+    "coverage": "./node_modules/.bin/istanbul cover node_modules/.bin/_mocha -- -R spec test/**.js"
   },
   "repository": {
     "type": "git",
@@ -25,6 +25,7 @@
   },
   "homepage": "https://github.com/jpgdev/testhelper#readme",
   "devDependencies": {
+    "coveralls": "^2.11.12",
     "faker": "^3.0.1",
     "istanbul": "^0.4.4",
     "mocha": "^3.0.2",

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -1,0 +1,23 @@
+'use strict';
+
+const should = require('should'),
+    TestHelper = require('../.');
+
+describe('Package Index', () => {
+
+    it('should expose the basic singleton instance', () => {
+        TestHelper.should.be.an.instanceOf(TestHelper.TestHelper);
+    });
+
+    it('should expose the constructor', () => {
+        TestHelper.TestHelper.should.be.a.Function();
+    });
+
+    it('should expose the basic StorageStrategy', () => {
+        TestHelper.StorageStrategy.should.be.a.Function();
+    });
+
+    it('should expose the Utilities', () => {
+        TestHelper.Utils.should.be.an.Object();
+    });
+});


### PR DESCRIPTION
- Adds support for Travis CI & Coveralls.
- Adds a basic test for the index.js.

_NOTE : The package currently has poor coverage because it is still missing the lib.js & examples coverage which will come later._
